### PR TITLE
Fix failing integration test on CI

### DIFF
--- a/itegration_suite_test.go
+++ b/itegration_suite_test.go
@@ -15,12 +15,15 @@ func TestClient(t *testing.T) {
 
 var cliPath string
 
-var _ = BeforeSuite(func() {
+var _ = SynchronizedBeforeSuite(func() []byte {
 	var err error
-	cliPath, err = gexec.Build("github.com/remove-bg/go")
+	path, err := gexec.Build("github.com/remove-bg/go")
 	Expect(err).ShouldNot(HaveOccurred())
+	return []byte(path)
+}, func(data []byte) {
+	cliPath = string(data)
 })
 
-var _ = AfterSuite(func() {
+var _ = SynchronizedAfterSuite(func() {
 	gexec.CleanupBuildArtifacts()
-})
+}, func() {})


### PR DESCRIPTION
Looks like a binary is still be built per test node, rather than once for all integration tests. This leads to what appears to be a race condition.

Example of failed build:
https://circleci.com/gh/remove-bg/go/24?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

## Solution

Use `SynchronizedBeforeSuite` to build exactly once before the `integration_test` package tests are run.

Ginkgo reference:
https://onsi.github.io/ginkgo/#managing-singleton-external-processes-in-parallel-test-suites