### PR TITLE
Add 'extra-api-options' flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,6 +21,7 @@ var (
 	imageChannels     string
 	bgColor           string
 	bgImageFile       string
+	extraApiOptions   string
 )
 
 // RootCmd is the entry point of command-line execution
@@ -44,12 +45,13 @@ var RootCmd = &cobra.Command{
 			ReprocessExisting:          reprocessExisting,
 			LargeBatchConfirmThreshold: confirmBatchOver,
 			ImageSettings: processor.ImageSettings{
-				Size:        imageSize,
-				Type:        imageType,
-				Channels:    imageChannels,
-				BgColor:     bgColor,
-				BgImageFile: bgImageFile,
-				Format:      imageFormat,
+				Size:            imageSize,
+				Type:            imageType,
+				Channels:        imageChannels,
+				BgColor:         bgColor,
+				BgImageFile:     bgImageFile,
+				Format:          imageFormat,
+				ExtraApiOptions: extraApiOptions,
 			},
 		}
 
@@ -70,6 +72,7 @@ func init() {
 	RootCmd.Flags().StringVar(&imageChannels, "channels", "", "Image channels")
 	RootCmd.Flags().StringVar(&bgColor, "bg-color", "", "Image background color")
 	RootCmd.Flags().StringVar(&bgImageFile, "bg-image-file", "", "Adds a background image from a file")
+	RootCmd.Flags().StringVar(&extraApiOptions, "extra-api-options", "", "Extra options to forward to the API (format: 'option1=val1&option2=val2')")
 
 	if len(apiKey) == 0 {
 		apiKey = os.Getenv("REMOVE_BG_API_KEY")

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -1,10 +1,12 @@
 package processor
 
 import (
+	"fmt"
 	"github.com/remove-bg/go/client"
 	"github.com/remove-bg/go/storage"
 	"log"
 	"net/http"
+	"net/url"
 )
 
 type Processor struct {
@@ -23,12 +25,13 @@ type Settings struct {
 }
 
 type ImageSettings struct {
-	Size        string
-	Type        string
-	Channels    string
-	BgColor     string
-	BgImageFile string
-	Format      string
+	Size            string
+	Type            string
+	Channels        string
+	BgColor         string
+	BgImageFile     string
+	Format          string
+	ExtraApiOptions string
 }
 
 func NewProcessor(apiKey string) Processor {
@@ -112,6 +115,18 @@ func imageSettingsToParams(imageSettings ImageSettings) map[string]string {
 
 	if len(imageSettings.Format) > 0 {
 		params["format"] = imageSettings.Format
+	}
+
+	if len(imageSettings.ExtraApiOptions) > 0 {
+		values, err := url.ParseQuery(imageSettings.ExtraApiOptions)
+
+		if err == nil {
+			for key, _ := range values {
+				params[key] = values.Get(key)
+			}
+		} else {
+			fmt.Printf("Unable to parse extra api options: %s\n", err)
+		}
 	}
 
 	return params

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -81,30 +81,51 @@ var _ = Describe("Processor", func() {
 		Expect(writerArg2).To(Equal([]byte("Processed1")))
 	})
 
-	It("passes non-empty image options to the client", func() {
-		fakeClient.RemoveFromFileReturnsOnCall(0, []byte("Processed1"), nil)
-		inputPaths := []string{"dir/image1.jpg"}
+	Describe("image options", func() {
+		It("passes non-empty image options to the client", func() {
+			fakeClient.RemoveFromFileReturnsOnCall(0, []byte("Processed1"), nil)
+			inputPaths := []string{"dir/image1.jpg"}
 
-		testSettings.ImageSettings = processor.ImageSettings{
-			Size:        "size-value",
-			Type:        "type-value",
-			Channels:    "channels-value",
-			BgColor:     "bg-color-value",
-			BgImageFile: "bg-image-file-value",
-			Format:      "format-value",
-		}
+			testSettings.ImageSettings = processor.ImageSettings{
+				Size:        "size-value",
+				Type:        "type-value",
+				Channels:    "channels-value",
+				BgColor:     "bg-color-value",
+				BgImageFile: "bg-image-file-value",
+				Format:      "format-value",
+			}
 
-		subject.Process(inputPaths, testSettings)
+			subject.Process(inputPaths, testSettings)
 
-		Expect(fakeClient.RemoveFromFileCallCount()).To(Equal(1))
-		_, _, params := fakeClient.RemoveFromFileArgsForCall(0)
+			Expect(fakeClient.RemoveFromFileCallCount()).To(Equal(1))
+			_, _, params := fakeClient.RemoveFromFileArgsForCall(0)
 
-		Expect(params["size"]).To(Equal("size-value"))
-		Expect(params["type"]).To(Equal("type-value"))
-		Expect(params["channels"]).To(Equal("channels-value"))
-		Expect(params["bg_color"]).To(Equal("bg-color-value"))
-		Expect(params["bg_image_file"]).To(Equal("bg-image-file-value"))
-		Expect(params["format"]).To(Equal("format-value"))
+			Expect(params["size"]).To(Equal("size-value"))
+			Expect(params["type"]).To(Equal("type-value"))
+			Expect(params["channels"]).To(Equal("channels-value"))
+			Expect(params["bg_color"]).To(Equal("bg-color-value"))
+			Expect(params["bg_image_file"]).To(Equal("bg-image-file-value"))
+			Expect(params["format"]).To(Equal("format-value"))
+		})
+
+		It("parses any extra API options into params", func() {
+			fakeClient.RemoveFromFileReturnsOnCall(0, []byte("Processed1"), nil)
+			inputPaths := []string{"dir/image1.jpg"}
+
+			testSettings.ImageSettings = processor.ImageSettings{
+				Size:            "size-value",
+				ExtraApiOptions: "option1=val1&option2=val2",
+			}
+
+			subject.Process(inputPaths, testSettings)
+
+			Expect(fakeClient.RemoveFromFileCallCount()).To(Equal(1))
+			_, _, params := fakeClient.RemoveFromFileArgsForCall(0)
+
+			Expect(params["size"]).To(Equal("size-value"))
+			Expect(params["option1"]).To(Equal("val1"))
+			Expect(params["option2"]).To(Equal("val2"))
+		})
 	})
 
 	Context("client error", func() {


### PR DESCRIPTION
Builds on #6 - once this is merged I'll update the PR base branch to `master`

Forwards extra options on to API, allowing options to be set which the CLI doesn't know about yet. Example:

```
removebg fixtures/person-in-field.jpg --extra-api-options 'crop_margin=30px'
```

## Context

Unfortunately there isn't a clean way to have arbitary flags in Cobra: https://github.com/spf13/cobra/issues/739, so this was felt to be the most flexible option without having to parse arguments after  a double dash `--` & having to document how this works.