### PR TITLE
Handle rate limit exceeded

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -121,7 +121,12 @@ var _ = Describe("Client", func() {
 			result, _, err := subject.RemoveFromFile(fixtureFile, "api-key", map[string]string{})
 
 			Expect(result).To(BeNil())
-			Expect(err).To(MatchError("File too large, Second error"))
+
+			re, ok := err.(*client.RequestError)
+			Expect(ok).To(BeTrue())
+
+			Expect(re.Error()).To(Equal("400: File too large, Second error"))
+			Expect(re.StatusCode).To(Equal(400))
 		})
 	})
 

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -87,6 +87,11 @@ func (p Processor) Process(rawInputPaths []string, settings Settings) {
 			p.Notifier.Success(inputPath, index+1, totalImages)
 		} else {
 			p.Notifier.Error(err, inputPath, index+1, totalImages)
+
+			clientErr, ok := err.(*client.RequestError)
+			if ok && clientErr.RateLimitExceeded() {
+				return // Halt processing loop
+			}
 		}
 	}
 }


### PR DESCRIPTION
Changes:

- Introduces a new `client.RequestError` type which holds extra info (like the status code)
- When the processor encounters a rate-limit-exceeded error, stop processing