### PR TITLE
Create output directory if required

### DIFF
--- a/processor/processor.go
+++ b/processor/processor.go
@@ -56,6 +56,11 @@ func NewProcessor(apiKey string, version string) Processor {
 }
 
 func (p Processor) Process(rawInputPaths []string, settings Settings) {
+	err := p.Storage.MkdirP(settings.OutputDirectory)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	inputPaths, err := p.Storage.ExpandPaths(rawInputPaths)
 	if err != nil {
 		log.Fatal(err)

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -67,6 +67,13 @@ var _ = Describe("Processor", func() {
 		Expect(clientArg1).To(Equal("dir/image1.jpg"))
 	})
 
+	It("create the output directory", func() {
+		subject.Process([]string{"dir/*.jpg"}, testSettings)
+
+		Expect(fakeStorage.MkdirPCallCount()).To(Equal(1))
+		Expect(fakeStorage.MkdirPArgsForCall(0)).To(Equal(testSettings.OutputDirectory))
+	})
+
 	It("coordinates the HTTP request and writing the result", func() {
 		fakeClient.RemoveFromFileReturnsOnCall(0, []byte("Processed1"), mimePng, nil)
 		fakeClient.RemoveFromFileReturnsOnCall(1, []byte("Processed2"), mimePng, nil)

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -11,6 +11,7 @@ type StorageInterface interface {
 	Write(path string, data []byte) error
 	FileExists(path string) bool
 	ExpandPaths(originalPaths []string) ([]string, error)
+	MkdirP(path string) error
 }
 
 type FileStorage struct {
@@ -51,4 +52,12 @@ func (FileStorage) ExpandPaths(originalPaths []string) ([]string, error) {
 	}
 
 	return resolvedPaths, nil
+}
+
+func (FileStorage) MkdirP(path string) error {
+	if len(path) == 0 {
+		return nil
+	}
+
+	return os.MkdirAll(path, 0755)
 }

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -3,7 +3,8 @@ package storage_test
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
+	"io/ioutil"
+	"os"
 	"path"
 	"runtime"
 
@@ -89,6 +90,29 @@ var _ = Describe("FileStorage", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(expanded).To(Equal(originals))
 			})
+		})
+	})
+
+	Describe("MkdirP", func() {
+		var tmpDir string
+
+		BeforeEach(func() {
+			dir, err := ioutil.TempDir("", "mkdirp-spec")
+			Expect(err).ToNot(HaveOccurred())
+
+			tmpDir = dir
+		})
+
+		AfterEach(func() {
+			os.RemoveAll(tmpDir)
+		})
+
+		It("creates deeply nested directories, if they don't exist", func() {
+			outputDir := path.Join(tmpDir, "nested1/nested2")
+
+			Expect(outputDir).ToNot(BeADirectory())
+			Expect(subject.MkdirP(outputDir)).Should(Succeed())
+			Expect(outputDir).To(BeADirectory())
 		})
 	})
 })

--- a/storage/storagefakes/fake_storage_interface.go
+++ b/storage/storagefakes/fake_storage_interface.go
@@ -32,6 +32,17 @@ type FakeStorageInterface struct {
 	fileExistsReturnsOnCall map[int]struct {
 		result1 bool
 	}
+	MkdirPStub        func(string) error
+	mkdirPMutex       sync.RWMutex
+	mkdirPArgsForCall []struct {
+		arg1 string
+	}
+	mkdirPReturns struct {
+		result1 error
+	}
+	mkdirPReturnsOnCall map[int]struct {
+		result1 error
+	}
 	WriteStub        func(string, []byte) error
 	writeMutex       sync.RWMutex
 	writeArgsForCall []struct {
@@ -176,6 +187,66 @@ func (fake *FakeStorageInterface) FileExistsReturnsOnCall(i int, result1 bool) {
 	}{result1}
 }
 
+func (fake *FakeStorageInterface) MkdirP(arg1 string) error {
+	fake.mkdirPMutex.Lock()
+	ret, specificReturn := fake.mkdirPReturnsOnCall[len(fake.mkdirPArgsForCall)]
+	fake.mkdirPArgsForCall = append(fake.mkdirPArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	fake.recordInvocation("MkdirP", []interface{}{arg1})
+	fake.mkdirPMutex.Unlock()
+	if fake.MkdirPStub != nil {
+		return fake.MkdirPStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.mkdirPReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeStorageInterface) MkdirPCallCount() int {
+	fake.mkdirPMutex.RLock()
+	defer fake.mkdirPMutex.RUnlock()
+	return len(fake.mkdirPArgsForCall)
+}
+
+func (fake *FakeStorageInterface) MkdirPCalls(stub func(string) error) {
+	fake.mkdirPMutex.Lock()
+	defer fake.mkdirPMutex.Unlock()
+	fake.MkdirPStub = stub
+}
+
+func (fake *FakeStorageInterface) MkdirPArgsForCall(i int) string {
+	fake.mkdirPMutex.RLock()
+	defer fake.mkdirPMutex.RUnlock()
+	argsForCall := fake.mkdirPArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeStorageInterface) MkdirPReturns(result1 error) {
+	fake.mkdirPMutex.Lock()
+	defer fake.mkdirPMutex.Unlock()
+	fake.MkdirPStub = nil
+	fake.mkdirPReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeStorageInterface) MkdirPReturnsOnCall(i int, result1 error) {
+	fake.mkdirPMutex.Lock()
+	defer fake.mkdirPMutex.Unlock()
+	fake.MkdirPStub = nil
+	if fake.mkdirPReturnsOnCall == nil {
+		fake.mkdirPReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.mkdirPReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeStorageInterface) Write(arg1 string, arg2 []byte) error {
 	var arg2Copy []byte
 	if arg2 != nil {
@@ -249,6 +320,8 @@ func (fake *FakeStorageInterface) Invocations() map[string][][]interface{} {
 	defer fake.expandPathsMutex.RUnlock()
 	fake.fileExistsMutex.RLock()
 	defer fake.fileExistsMutex.RUnlock()
+	fake.mkdirPMutex.RLock()
+	defer fake.mkdirPMutex.RUnlock()
 	fake.writeMutex.RLock()
 	defer fake.writeMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}


### PR DESCRIPTION
If the output directory is not specified, or already exists, then there's no side effect.

Fixes https://github.com/remove-bg/go/issues/12