### PR TITLE
Fix skipping existing images

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -52,7 +52,7 @@ var RootCmd = &cobra.Command{
 				Channels:        imageChannels,
 				BgColor:         bgColor,
 				BgImageFile:     bgImageFile,
-				Format:          strings.ToLower(imageFormat),
+				OutputFormat:    strings.ToLower(imageFormat),
 				ExtraApiOptions: extraApiOptions,
 			},
 		}

--- a/processor/determine_output_path.go
+++ b/processor/determine_output_path.go
@@ -14,8 +14,8 @@ func DetermineOutputPath(inputPath string, settings Settings) string {
 	extensionlessFileName := strings.TrimSuffix(fileName, path.Ext(fileName))
 	outputExtension := defaultOutputExtension
 
-	if len(settings.ImageSettings.Format) > 0 {
-		outputExtension = "." + settings.ImageSettings.Format
+	if len(settings.ImageSettings.OutputFormat) > 0 {
+		outputExtension = "." + settings.ImageSettings.OutputFormat
 	}
 
 	if len(outputDirectory) == 0 {

--- a/processor/determine_output_path_test.go
+++ b/processor/determine_output_path_test.go
@@ -37,7 +37,7 @@ var _ = Describe("DetermineOutputPath", func() {
 			settings := Settings{
 				OutputDirectory: "out",
 				ImageSettings: ImageSettings{
-					Format: "jpg",
+					OutputFormat: "jpg",
 				},
 			}
 

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -104,7 +104,7 @@ var _ = Describe("Processor", func() {
 
 			inputPaths := []string{"dir/image1.jpg", "dir/image2.jpg"}
 			testSettings.OutputDirectory = "out-dir"
-			testSettings.ImageSettings.Format = processor.FormatZip
+			testSettings.ImageSettings.OutputFormat = processor.FormatZip
 
 			subject.Process(inputPaths, testSettings)
 
@@ -126,7 +126,7 @@ var _ = Describe("Processor", func() {
 		It("upgrades the format to zip behind the scenes", func() {
 			inputPaths := []string{"dir/image1.jpg", "dir/image2.jpg"}
 			testSettings.OutputDirectory = "out-dir"
-			testSettings.ImageSettings.Format = processor.FormatPng
+			testSettings.ImageSettings.OutputFormat = processor.FormatPng
 
 			subject.Process(inputPaths, testSettings)
 
@@ -138,7 +138,7 @@ var _ = Describe("Processor", func() {
 		It("delegates to the compositor", func() {
 			inputPaths := []string{"dir/image1.jpg", "dir/image2.jpg"}
 			testSettings.OutputDirectory = "out-dir"
-			testSettings.ImageSettings.Format = processor.FormatPng
+			testSettings.ImageSettings.OutputFormat = processor.FormatPng
 
 			subject.Process(inputPaths, testSettings)
 
@@ -152,7 +152,7 @@ var _ = Describe("Processor", func() {
 		It("allows the optimization to be skipped", func() {
 			inputPaths := []string{"dir/image1.jpg", "dir/image2.jpg"}
 			testSettings.OutputDirectory = "out-dir"
-			testSettings.ImageSettings.Format = processor.FormatPng
+			testSettings.ImageSettings.OutputFormat = processor.FormatPng
 			testSettings.SkipPngFormatOptimization = true
 
 			subject.Process(inputPaths, testSettings)
@@ -160,6 +160,20 @@ var _ = Describe("Processor", func() {
 			Expect(fakeClient.RemoveFromFileCallCount()).To(Equal(2))
 			_, _, params := fakeClient.RemoveFromFileArgsForCall(0)
 			Expect(params["format"]).To(Equal(processor.FormatPng))
+		})
+
+		It("skips processing if the output PNG file exists", func() {
+			testSettings.OutputDirectory = ""
+			testSettings.ImageSettings.OutputFormat = processor.FormatPng
+
+			inputPaths := []string{"dir/image1.jpg"}
+			fakeStorage.FileExistsReturnsOnCall(0, true)
+
+			subject.Process(inputPaths, testSettings)
+
+			Expect(fakeNotifier.SkipCallCount()).To(Equal(1))
+			Expect(fakeClient.RemoveFromFileCallCount()).To(Equal(0))
+			Expect(fakeStorage.FileExistsArgsForCall(0)).To(Equal("dir/image1-removebg.png"))
 		})
 	})
 
@@ -169,12 +183,12 @@ var _ = Describe("Processor", func() {
 			inputPaths := []string{"dir/image1.jpg"}
 
 			testSettings.ImageSettings = processor.ImageSettings{
-				Size:        "size-value",
-				Type:        "type-value",
-				Channels:    "channels-value",
-				BgColor:     "bg-color-value",
-				BgImageFile: "bg-image-file-value",
-				Format:      "format-value",
+				Size:         "size-value",
+				Type:         "type-value",
+				Channels:     "channels-value",
+				BgColor:      "bg-color-value",
+				BgImageFile:  "bg-image-file-value",
+				OutputFormat: "format-value",
 			}
 
 			subject.Process(inputPaths, testSettings)


### PR DESCRIPTION
Unless reprocessing is allowed, existing images should be skipped to preserve credits.

This functionality was broken when the auto-upgrade from PNG to ZIP was introduced. It ended up checking if the `.zip` file already exists, which it wouldn't because a `.png` file is emitted when the `zip` format is used.

Fixes https://github.com/remove-bg/go/issues/16

Source of bug: https://github.com/remove-bg/go/pull/7/commits/e40648c6b73ec916a90eaf253c8e152b3560312f

--

Changes:

- Introduce the concept of a 'Transfer Format', which is distinct from the 'Output Format'. This avoids confusion.
  - Transfer format is passed to the API, via the Client
  - Output format is used for checking if the processed image already exists